### PR TITLE
Fix: zoom not fitting waypoints fully #221

### DIFF
--- a/frontend/src/components/MapComponent.tsx
+++ b/frontend/src/components/MapComponent.tsx
@@ -167,7 +167,7 @@ const MapComponent: React.FC<MapComponentProps> = ({
       .extend(toLocked.geometry.coordinates);
 
     mapRef.current.fitBounds(bounds, {
-      padding: 80,
+      padding: 110,
       duration: 1500
     });
   }, [fromLocked, toLocked]);


### PR DESCRIPTION
- Increased padding in MapComponent.tsx by 30 to always fit both waypoints when route is found and map zooms