### PR TITLE
Fix/autofill suggestions do not have duplicates #301

### DIFF
--- a/backend/src/endpoints/geocode.py
+++ b/backend/src/endpoints/geocode.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request, Path
 import httpx
 from utils.poi_utils import compose_photon_suggestions
 from utils.decorators import require_area_config
+from utils.poi_utils import remove_double_osm_features
 
 router = APIRouter()
 
@@ -26,6 +27,9 @@ async def geocode_forward(request: Request, value: str = Path(...)):
         async with httpx.AsyncClient() as client:
             response = await client.get(photon_url)
             photon_suggestions = response.json()
+            trimmed_features = remove_double_osm_features(
+                photon_suggestions.get("features", []))
+            photon_suggestions["features"] = trimmed_features
     except httpx.HTTPError as exc:
         print(f"HTTP Exception for {exc.request.url} - {exc}")
         return []

--- a/backend/src/utils/poi_utils.py
+++ b/backend/src/utils/poi_utils.py
@@ -1,12 +1,12 @@
-"""POI utils for classifying Photon/OSM features and building full addresses."""
-
-POI_KEYS = {"amenity", "tourism", "shop",
+"""Utilities for processing address suggestions from Photon."""
+# classify POIs using common osm keys
+poi_keys = {"amenity", "tourism", "shop",
             "leisure", "historic", "office", "craft"}
 
 
 def build_full_address(properties: dict) -> str:
-    """
-    Build a readable full_address from Photon properties.
+    """Build a readable full_address from Photon properties.
+
     Returns a string with a trailing space for compatibility with existing tests.
     """
     name = properties.get("name") or ""
@@ -20,18 +20,32 @@ def build_full_address(properties: dict) -> str:
 
 
 def compose_photon_suggestions(photon_suggestions: dict) -> dict:
-    """
-    Classify Photon features into addresses and POIs and compose final list.
-    Keeps up to 4 addresses and up to 2 POIs (with interleave rule if few addresses).
+    """Classify Photon features into addresses and POIs and compose final list.
+
+    Keeps up to 4 addresses and up to 2 POIs (with a small interleave rule when
+    there are few addresses).
     """
     poi_features = []
     address_features = []
+    # track seen full_address strings (normalized via strip) to avoid exact duplicates
+    seen_full_addresses = set()
 
     for feature in photon_suggestions.get("features", []):
         props = feature.get("properties", {})
-        feature["full_address"] = build_full_address(props)
+        # build and normalize full_address (strip trailing/leading whitespace)
+        full_addr = build_full_address(props)
+        if isinstance(full_addr, str):
+            full_addr = full_addr.strip()
+        feature["full_address"] = full_addr
+
+        # skip exact duplicate full_address entries
+        if full_addr and full_addr in seen_full_addresses:
+            continue
+        if full_addr:
+            seen_full_addresses.add(full_addr)
+
         osm_key = props.get("osm_key")
-        if osm_key in POI_KEYS:
+        if osm_key in poi_keys:
             poi_features.append(feature)
         else:
             address_features.append(feature)
@@ -46,3 +60,18 @@ def compose_photon_suggestions(photon_suggestions: dict) -> dict:
 
     photon_suggestions["features"] = final_features
     return photon_suggestions
+
+
+def remove_double_osm_features(features: list[dict]) -> list[dict]:
+    """Remove features with duplicate OSM IDs, keeping the first occurrence."""
+    seen_osm_ids = set()
+    unique_features = []
+
+    for feature in features:
+        props = feature.get("properties", {})
+        osm_id = props.get("osm_id")
+        if osm_id not in seen_osm_ids:
+            seen_osm_ids.add(osm_id)
+            unique_features.append(feature)
+
+    return unique_features

--- a/backend/tests/unit/utils/test_poi_utils.py
+++ b/backend/tests/unit/utils/test_poi_utils.py
@@ -1,15 +1,38 @@
-# tests/test_poi_utils.py
-import pytest
-from src.utils.poi_utils import build_full_address, compose_photon_suggestions, POI_KEYS
+"""Unit tests for utils.poi_utils helpers."""
+
+import src.utils.poi_utils as addr
+
+
+def make_feature(name, osm_key=None, osm_id=None, osm_type=None, coords=None, street=None, housenumber=None, city=None):
+    props = {"name": name}
+    if osm_key is not None:
+        props["osm_key"] = osm_key
+    if osm_id is not None:
+        props["osm_id"] = osm_id
+    if osm_type is not None:
+        props["osm_type"] = osm_type
+    if street is not None:
+        props["street"] = street
+    if housenumber is not None:
+        props["housenumber"] = housenumber
+    if city is not None:
+        props["city"] = city
+
+    feature = {
+        "type": "Feature",
+        "properties": props,
+        "geometry": {"type": "Point", "coordinates": coords or [13.4, 52.5]},
+    }
+    return feature
 
 
 def test_build_full_address_empty():
-    assert build_full_address({}) == ""
+    assert addr.build_full_address({}) == ""
 
 
 def test_build_full_address_name_only():
     props = {"name": "Cafe Test"}
-    assert build_full_address(props) == "Cafe Test "
+    assert addr.build_full_address(props) == "Cafe Test "
 
 
 def test_build_full_address_with_all_fields_and_int():
@@ -19,19 +42,12 @@ def test_build_full_address_with_all_fields_and_int():
         "housenumber": 3,
         "city": "Berlin",
     }
-    assert build_full_address(props) == "Die Mitte Alexanderplatz 3 Berlin "
-
-
-def test_build_full_address_with_missing_fields():
-    props = {"name": "Cafe", "city": "Helsinki"}
-    assert build_full_address(props) == "Cafe Helsinki "
-
-
-def make_feature(name, osm_key=None):
-    return {"properties": {"name": name, "osm_key": osm_key}}
+    assert addr.build_full_address(
+        props) == "Die Mitte Alexanderplatz 3 Berlin "
 
 
 def test_compose_photon_suggestions_interleave_pois():
+    # 1 address and 2 POIs -> first POI should be placed before the address
     photon = {
         "features": [
             make_feature("Addr A", osm_key=None),
@@ -39,7 +55,8 @@ def test_compose_photon_suggestions_interleave_pois():
             make_feature("Poi 2", osm_key="tourism"),
         ]
     }
-    out = compose_photon_suggestions(photon)
+
+    out = addr.compose_photon_suggestions(photon)
     names = [f["properties"]["name"] for f in out["features"]]
     assert names[0] in {"Poi 1", "Poi 2"}
     assert "Addr A" in names
@@ -47,28 +64,36 @@ def test_compose_photon_suggestions_interleave_pois():
 
 
 def test_compose_photon_suggestions_limits_and_order():
-    features = [make_feature(f"Addr {i}") for i in range(5)]
-    features += [make_feature(f"Poi {j}", osm_key="amenity") for j in range(3)]
+    # 5 addresses and 3 POIs -> keep first 4 addresses then first 2 POIs
+    features = []
+    for i in range(5):
+        features.append(make_feature(f"Addr {i}", osm_key=None))
+    for j in range(3):
+        features.append(make_feature(f"Poi {j}", osm_key="amenity"))
+
     photon = {"features": features}
-    out = compose_photon_suggestions(photon)
+    out = addr.compose_photon_suggestions(photon)
     names = [f["properties"]["name"] for f in out["features"]]
 
-    # First 4 addresses
     assert names[:4] == [f"Addr {i}" for i in range(4)]
-    # Then first 2 POIs
     assert names[4:] == ["Poi 0", "Poi 1"]
     assert len(out["features"]) == 6
 
 
 def test_compose_photon_suggestions_empty():
     photon = {"features": []}
-    out = compose_photon_suggestions(photon)
+    out = addr.compose_photon_suggestions(photon)
     assert out["features"] == []
 
 
-def test_compose_photon_suggestions_all_pois():
-    features = [make_feature(f"Poi {i}", osm_key="amenity") for i in range(5)]
-    photon = {"features": features}
-    out = compose_photon_suggestions(photon)
-    names = [f["properties"]["name"] for f in out["features"]]
-    assert names == ["Poi 0", "Poi 1"]  # max 2
+def test_remove_double_osm_features_dedupes():
+    f1 = make_feature("Place A", osm_id=123, osm_type="node")
+    f2 = make_feature("Place A duplicate", osm_id=123, osm_type="node")
+    f3 = make_feature("Different", osm_id=456, osm_type="node")
+    features = [f1, f2, f3]
+
+    unique = addr.remove_double_osm_features(features)
+    # should keep first occurrence of osm_id 123 and include osm_id 456
+    assert len(unique) == 2
+    assert unique[0]["properties"]["osm_id"] == 123
+    assert unique[1]["properties"]["osm_id"] == 456


### PR DESCRIPTION
Address suggestion related stuff moved to their own files.

Added two different address checks: One for exact match and another for checking double OSM ids.

--Made this fully new PR because the dev had so many changes and different file names etc.