### PR TITLE
FIX: flicker bug

### DIFF
--- a/frontend/src/styles/SideBar.css
+++ b/frontend/src/styles/SideBar.css
@@ -45,6 +45,7 @@
 }
 
 .route-card-base {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -204,11 +205,12 @@
 }
 
 .route-loading-overlay {
-  position: relative;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 8px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Changed .route-loading-overlay
position from absolute to relative
removed background color

Flicker was caused by loading being ontop of entire page. Now contained into balanced route card.