### PR TITLE
Fix: Destination suggestion show when returning from loop view #355

### DIFF
--- a/frontend/src/components/SideBar.tsx
+++ b/frontend/src/components/SideBar.tsx
@@ -397,7 +397,7 @@ const SideBar: React.FC<SideBarProps> = ({
               placeholder='Destination'
               value={to}
               onChange={HandleToChange}
-              suggestions={toSuggestions}
+              suggestions={toInputSelected.current ? [] : toSuggestions}
               onSelect={(place) => {
                 toInputSelected.current = true;
                 onToSelect(place);


### PR DESCRIPTION
Added a one-liner to check if the same destination address has already been searched for.